### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the code in a number of places to obtain a working model (these are marked by
    You should be able to test this as follows:
    ```
    $ python test_step2.py data/jsoup/src/main/java/org/jsoup/Jsoup.java.proto | tail -n -1
-   ['public', 'static', 'boolean', 'isvalid', 'lparen', 'string', 'bodyhtml', 'comma', 'whitelist', 'whitelist', 'rparen', 'lbrace', 'return', 'new', 'cleaner', 'lparen', 'whitelist', 'rparen', 'dot', 'isvalidbodyhtml', 'lparen', 'bodyhtml', 'rparen', 'semi', 'rbrace', 'rbrace']
+   ['public', 'static', 'boolean', 'isvalid', 'lparen', 'string', 'bodyhtml', 'comma', 'whitelist', 'whitelist', 'rparen', 'lbrace', 'return', 'new', 'cleaner', 'lparen', 'whitelist', 'rparen', 'dot', 'isvalidbodyhtml', 'lparen', 'bodyhtml', 'rparen', 'semi', 'rbrace']
    ```
 
 3. In `dataset.py`, `build_vocab_from_data_dir` needs to be completed to 


### PR DESCRIPTION
The original method from Jsoup.java seems to contain only one `rbrace` token.

![image](https://user-images.githubusercontent.com/18227298/73069210-0c977580-3ea5-11ea-9b49-d108962d1876.png)
